### PR TITLE
prevent hanging and orphaning the supervisor on service stop

### DIFF
--- a/App.config
+++ b/App.config
@@ -25,6 +25,7 @@
   </log4net>
   <appSettings>
     <add key="debug" value="false" />
+    <add key="HAB_FEAT_IGNORE_SIGNALS" value="true" />
     <add key="launcherArgs" value="--no-color" />
   </appSettings>
 </configuration>

--- a/plan.ps1
+++ b/plan.ps1
@@ -1,6 +1,6 @@
 ﻿$pkg_name="windows-service"
 $pkg_origin="core"
-$pkg_version="0.3.0"
+$pkg_version="0.3.1"
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_license=@('Apache-2.0')
 $pkg_description="A Windows Service for runnung the Habitat Supervisor"


### PR DESCRIPTION
The 0.62.0 Supervisor introduced an ssue where it will not respond to a ctrl+c event and eventually the `OnStop` will give up and orphan the supervisor and launcher processes.

This PR does three things to improve this scenario:

1. Capture any win32 errors from the native console calls. Originally I suspected one of these calls was failing. Turns out that was not the case but we should keep these.
2. f for some reason the launcher fails to exit, forcibly kill it so that it is not orphaned.
3. the 0.63.0 Supervisor will include a new `IgnoreSignals` feature that if set, will not override the default ctrl+c handler (see https://github.com/habitat-sh/habitat/pull/5603). This will set that feature by default.

Signed-off-by: mwrock <matt@mattwrock.com>